### PR TITLE
Only access the request object when possible

### DIFF
--- a/lib/marginalia/comment.rb
+++ b/lib/marginalia/comment.rb
@@ -72,7 +72,7 @@ module Marginalia
       end
 
       def self.request_uuid
-        @controller.request.uuid
+        @controller.request.uuid if @controller.respond_to?(:request) && @controller.request.respond_to?(:uuid)
       end
   end
 


### PR DESCRIPTION
Resolves errors when `@controller` is `nil`, e.g. rake tasks and console. This change follows the example of the checks in `self.controller` and `self.action`.
